### PR TITLE
feat: support unmanaged models (#1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "serverless-v2-aws-documentation",
-  "version": "2.0.4",
-  "description": "Serverless 2.0 plugin to add documentation and models to the serverless generated API Gateway",
+  "version": "2.0.5",
+  "description": "Serverless 2+ plugin to add documentation and models to the serverless generated API Gateway",
   "main": "src/index.js",
   "scripts": {
     "codecov": "cat coverage/*/lcov.info | codecov",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-v2-aws-documentation",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "Serverless 2+ plugin to add documentation and models to the serverless generated API Gateway",
   "main": "src/index.js",
   "scripts": {

--- a/src/documentation.js
+++ b/src/documentation.js
@@ -229,8 +229,8 @@ module.exports = function() {
         const updateMethod = method => {
           const resourceName = this.normalizePath(eventTypes.http.path);
           const methodLogicalId = this.getMethodLogicalId(resourceName, method);
-          const resource = this.cfTemplate.Resources[methodLogicalId];  
-          resource.DependsOn = new Set();
+          const resource = this.cfTemplate.Resources[methodLogicalId];
+          resource.DependsOn = resource.DependsOn ? new Set(resource.DependsOn) : new Set();
           this.addMethodResponses(resource, eventTypes.http.documentation, this._models);
           this.addRequestModels(resource, eventTypes.http.documentation, this._models);
           if (!this.options['doc-safe-mode']) {
@@ -245,9 +245,9 @@ module.exports = function() {
               'querystring'
             );
             this.addDocumentationToApiGateway(
-                resource,
-                eventTypes.http.documentation.pathParams,
-                'path'
+              resource,
+              eventTypes.http.documentation.pathParams,
+              'path'
             );
           }
           resource.DependsOn = Array.from(resource.DependsOn);

--- a/src/documentation.js
+++ b/src/documentation.js
@@ -104,7 +104,11 @@ module.exports = function() {
           console.info(msg);
           return Promise.reject(msg);
         }, err => {
-          if (err.message === 'Invalid Documentation version specified') {
+          if (
+            err.providerError
+            && err.providerError.statusCode === 404
+            && err.providerError.message === 'Invalid Documentation version specified'
+          ) {
             return Promise.resolve();
           }
 

--- a/src/documentation.js
+++ b/src/documentation.js
@@ -225,8 +225,8 @@ module.exports = function() {
           const methodLogicalId = this.getMethodLogicalId(resourceName, method);
           const resource = this.cfTemplate.Resources[methodLogicalId];  
           resource.DependsOn = new Set();
-          this.addMethodResponses(resource, eventTypes.http.documentation);
-          this.addRequestModels(resource, eventTypes.http.documentation);
+          this.addMethodResponses(resource, eventTypes.http.documentation, this._models);
+          this.addRequestModels(resource, eventTypes.http.documentation, this._models);
           if (!this.options['doc-safe-mode']) {
             this.addDocumentationToApiGateway(
               resource,

--- a/src/documentation.js
+++ b/src/documentation.js
@@ -121,7 +121,8 @@ module.exports = function() {
           })
         )
         .then(results => {
-          const existing = new Map(results.items.map(p => [JSON.stringify(p.location), p]))
+          const stringify = o => JSON.stringify(o, Object.keys(o).sort())
+          const existing = new Map(results.items.map(p => [stringify(p.location), p]))
           return Promise.all(this.documentationParts.map(p => {
             p.properties = JSON.stringify(p.properties)
             const k = JSON.stringify(p.location)

--- a/src/index.js
+++ b/src/index.js
@@ -204,7 +204,8 @@ class ServerlessV2AWSDocumentation {
         return Promise.resolve();
       }
 
-      return Promise.reject(err);
+      // return Promise.reject(err);
+      return Promise.resolve();
     });
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -162,12 +162,17 @@ class ServerlessV2AWSDocumentation {
     }
 
     if (this.customVars.documentation.models) {
-      const cfModelCreator = this.createCfModel(restApiId);
+      this._models = this.customVars.documentation.models.reduce((acc, m) => {
+        acc[m.name] = m;
+        return acc;
+      }, {});
+
+      const cfModelCreator = this.createCfModel(restApiId, this._models);
 
       // Add model resources
       const models = this.customVars.documentation.models.map(cfModelCreator)
         .reduce((modelObj, model) => {
-          modelObj[`${model.Properties.Name}Model`] = model;
+          if (model) modelObj[`${model.Properties.Name}Model`] = model;
           return modelObj;
         }, {});
       Object.assign(this.cfTemplate.Resources, models);

--- a/src/index.js
+++ b/src/index.js
@@ -192,7 +192,8 @@ class ServerlessV2AWSDocumentation {
   }
 
   afterDeploy() {
-    if (!this.customVars.documentation) return;
+    // obataku: add shortcircuit to skip documentation parts entirely
+    if (this.options['skip-documentation-parts'] || !this.customVars.documentation) return;
     const stackName = this.serverless.providers.aws.naming.getStackName(this.options.stage);
     return this.serverless.providers.aws.request('CloudFormation', 'describeStacks', { StackName: stackName },
       this.options.stage,

--- a/src/index.js
+++ b/src/index.js
@@ -193,7 +193,7 @@ class ServerlessV2AWSDocumentation {
 
   afterDeploy() {
     // obataku: add shortcircuit to skip documentation parts entirely
-    if (this.options['skip-documentation-parts'] || !this.customVars.documentation) return;
+    if (!this.customVars.documentation || this.customVars.documentation.skipParts) return;
     const stackName = this.serverless.providers.aws.naming.getStackName(this.options.stage);
     return this.serverless.providers.aws.request('CloudFormation', 'describeStacks', { StackName: stackName },
       this.options.stage,
@@ -204,8 +204,7 @@ class ServerlessV2AWSDocumentation {
         return Promise.resolve();
       }
 
-      // return Promise.reject(err);
-      return Promise.resolve();
+      return Promise.reject(err);
     });
   }
 

--- a/src/models.js
+++ b/src/models.js
@@ -1,6 +1,6 @@
 'use strict';
 
-function replaceModelRefs(restApiId, cfModel) {
+function replaceModelRefs(restApiId, cfModel, models) {
     if (!cfModel.Properties || !cfModel.Properties.Schema || Object.keys(cfModel.Properties.Schema).length == 0) {
       return cfModel;
     }
@@ -21,10 +21,16 @@ function replaceModelRefs(restApiId, cfModel) {
                             ]
                         ]
                     };
-                    if (!cfModel.DependsOn) {
-                        cfModel.DependsOn = new Set();
+
+                    const name = match[1];
+                    const model = models[name];
+                    if (!model) throw new Error(`unrecognized model: ${name}`);
+                    if (model.managed !== false) {
+                        if (!cfModel.DependsOn) {
+                            cfModel.DependsOn = new Set();
+                        }
+                        cfModel.DependsOn.add(name + 'Model');
                     }
-                    cfModel.DependsOn.add(match[1]+'Model');
                 }
             } else if (typeof obj[key] === 'object' && obj[key] !== null) {
                 replaceRefs(obj[key]);
@@ -40,8 +46,10 @@ function replaceModelRefs(restApiId, cfModel) {
 }
 
 module.exports = {
-  createCfModel: function createCfModel(restApiId) {
+  createCfModel: function createCfModel(restApiId, models) {
     return function(model) {
+
+      if (model.managed === false) return null
 
       let cfModel = {
         Type: 'AWS::ApiGateway::Model',
@@ -57,17 +65,20 @@ module.exports = {
         cfModel.Properties.Description = model.description
       }
 
-      return replaceModelRefs(restApiId, cfModel)
+      return replaceModelRefs(restApiId, cfModel, models)
     }
   },
 
-  addModelDependencies: function addModelDependencies(models, resource) {
+  addModelDependencies: function addModelDependencies(models, resource, _models) {
     Object.keys(models).forEach(contentType => {
-      resource.DependsOn.add(`${models[contentType]}Model`);
+      const name = models[contentType];
+      const model = _models[name];
+      if (!model) throw new Error(`unrecognized model: ${name}`);
+      if (model.managed !== false) resource.DependsOn.add(`${name}Model`);
     });
   },
 
-  addMethodResponses: function addMethodResponses(resource, documentation) {
+  addMethodResponses: function addMethodResponses(resource, documentation, models) {
     if (documentation.methodResponses) {
       if (!resource.Properties.MethodResponses) {
         resource.Properties.MethodResponses = [];
@@ -96,15 +107,15 @@ module.exports = {
 
         if (response.responseModels) {
           _response.ResponseModels = response.responseModels;
-          this.addModelDependencies(_response.ResponseModels, resource);
+          this.addModelDependencies(_response.ResponseModels, resource, models);
         }
       });
     }
   },
 
-  addRequestModels: function addRequestModels(resource, documentation) {
+  addRequestModels: function addRequestModels(resource, documentation, models) {
     if (documentation.requestModels && Object.keys(documentation.requestModels).length > 0) {
-      this.addModelDependencies(documentation.requestModels, resource);
+      this.addModelDependencies(documentation.requestModels, resource, models);
       resource.Properties.RequestModels = documentation.requestModels;
     }
   }


### PR DESCRIPTION
adds support for specifying & referencing models by name without binding them to a particular serverless application & cloudformation stack

usage:
```yaml
custom:
  documentation:
    models:
      - name: RFC7807
        managed: false
      - name: Foo
        contentType: application/json
        schema: ${file(foo.json)}
```